### PR TITLE
Respect fileCkeckExists option, even when we have a host

### DIFF
--- a/packages/ts-transform-paths/src/ImportPathInternalResolver.ts
+++ b/packages/ts-transform-paths/src/ImportPathInternalResolver.ts
@@ -38,8 +38,9 @@ export class ImportPathInternalResolver {
         let newImportPath = path.join(currentDir, newImport)
         if (newImportPath[0] === '.') newImportPath = newImportPath.substring(2)
         for (let part of tsParts) {
+          if (!config.fileCkeckExists) return newImport;
           if (host.getSourceFile(`${newImportPath}${part}`)) return newImport
-        }  
+        }
       }
 
       if (emitHost && emitHost.fileExists) {

--- a/packages/ts-transform-paths/src/ImportPathInternalResolver.ts
+++ b/packages/ts-transform-paths/src/ImportPathInternalResolver.ts
@@ -39,7 +39,7 @@ export class ImportPathInternalResolver {
         if (newImportPath[0] === '.') newImportPath = newImportPath.substring(2)
         for (let part of tsParts) {
           if (!config.fileCkeckExists) return newImport;
-          if (host.getSourceFile(`${newImportPath}${part}`)) return newImport
+          if (host.fileExists(`${newImportPath}${part}`)) return newImport
         }
       }
 


### PR DESCRIPTION
This is needed in case you're using this transformer with `ts.transpileModule`. In which case, `isolatedModules=true`.

[TypeScript specifies a one-off function that only returns the source for the module we're currently transpiling.](
https://github.com/microsoft/TypeScript/blob/4fe27222ca2d012dad541b43d791ae12f1cf6985/src/services/transpile.ts#L68) This means that `getSourceFile` will only return `true` for the module being transpiled. This can be worked around by setting `fileCkeckExists` to true, but this option is not respected when there is a program and therefor a host.

A practical example where this problematic is `ts-jest` with the `isolatedModules` option set to `true`. See: https://github.com/kulshekhar/ts-jest/blob/v25.2.0/src/compiler.ts#L98 In this case, `ts-jest` uses `ts.transpileModule` and without the `fileCkeckExists` option properly working, transformation won't happen.

